### PR TITLE
[FEAT] 액세스 토큰&리프레시 토큰 만료 시 처리 로직 추가 (진행중)

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -34,6 +34,7 @@ android {
 dependencies {
 
     implementation(project(":domain"))
+    implementation(project(":presentation:login"))
 
     implementation(jetpackDeps)
     implementation(coroutines)

--- a/data/src/main/java/com/yapp/android2/data/di/ServiceModule.kt
+++ b/data/src/main/java/com/yapp/android2/data/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
+import com.google.gson.Gson
 import com.yapp.android2.data.service.LoginService
 import com.yapp.android2.data.service.NotificationService
 import com.yapp.android2.data.service.ProductsService
@@ -52,9 +53,10 @@ internal object ServiceModule {
     @Provides
     @Singleton
     fun provideRetrofit(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
+        gson: Gson
     ): Retrofit {
-        val headerInterceptor = HeaderInterceptor(context)
+        val headerInterceptor = HeaderInterceptor(context, gson)
         val logInterceptor = HttpLoggingInterceptor { message ->
             Timber.tag("OKHttp").d(message)
         }

--- a/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSource.kt
+++ b/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSource.kt
@@ -8,6 +8,8 @@ interface LoginLocalDataSource: LocalDataSource {
     fun getAccessToken(): String
     fun saveKakaoAccessToken(kakaoToken: String)
     fun getKakaoAccessToken(): String
+    fun saveRefreshToken(refreshToken: String)
+    fun getRefreshToken(): String
     fun saveUser(user: User)
     fun getUser(): User
 }

--- a/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.yapp.android2.data.local.BestFriendSharedPreferenceProviderImpl
 import com.yapp.android2.domain.entity.User
 import com.yapp.android2.domain.key.ACCESS_TOKEN_KEY
 import com.yapp.android2.domain.key.KAKAO_ACCESS_TOKEN_KEY
+import com.yapp.android2.domain.key.REFRESH_TOKEN
 import javax.inject.Inject
 
 class LoginLocalDataSourceImpl @Inject constructor(
@@ -23,6 +24,14 @@ class LoginLocalDataSourceImpl @Inject constructor(
 
     override fun getKakaoAccessToken(): String {
         return preference.getString(KAKAO_ACCESS_TOKEN_KEY)
+    }
+
+    override fun saveRefreshToken(refreshToken: String) {
+        preference.putString(REFRESH_TOKEN, refreshToken)
+    }
+
+    override fun getRefreshToken(): String {
+        return preference.getString(REFRESH_TOKEN)
     }
 
     override fun saveUser(user: User) {

--- a/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/android2/data/local/login/LoginLocalDataSourceImpl.kt
@@ -4,7 +4,7 @@ import com.yapp.android2.data.local.BestFriendSharedPreferenceProviderImpl
 import com.yapp.android2.domain.entity.User
 import com.yapp.android2.domain.key.ACCESS_TOKEN_KEY
 import com.yapp.android2.domain.key.KAKAO_ACCESS_TOKEN_KEY
-import com.yapp.android2.domain.key.REFRESH_TOKEN
+import com.yapp.android2.domain.key.REFRESH_TOKEN_KEY
 import javax.inject.Inject
 
 class LoginLocalDataSourceImpl @Inject constructor(
@@ -27,11 +27,11 @@ class LoginLocalDataSourceImpl @Inject constructor(
     }
 
     override fun saveRefreshToken(refreshToken: String) {
-        preference.putString(REFRESH_TOKEN, refreshToken)
+        preference.putString(REFRESH_TOKEN_KEY, refreshToken)
     }
 
     override fun getRefreshToken(): String {
-        return preference.getString(REFRESH_TOKEN)
+        return preference.getString(REFRESH_TOKEN_KEY)
     }
 
     override fun saveUser(user: User) {

--- a/data/src/main/java/com/yapp/android2/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/android2/data/repository/LoginRepositoryImpl.kt
@@ -30,6 +30,12 @@ class LoginRepositoryImpl @Inject constructor(
 
     override fun getKakaoAccessToken(): String = loginLocalDataSource.getKakaoAccessToken()
 
+    override fun saveRefreshToken(refreshToken: String) {
+        loginLocalDataSource.saveRefreshToken(refreshToken)
+    }
+
+    override fun getRefreshToken(): String = loginLocalDataSource.getRefreshToken()
+
     override fun saveUser(user: User) {
         loginLocalDataSource.saveUser(user)
     }

--- a/data/src/main/java/com/yapp/android2/data/service/Service.kt
+++ b/data/src/main/java/com/yapp/android2/data/service/Service.kt
@@ -7,7 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 interface Service {
     companion object {
-        private const val BASE_URL = "https://jeol-chin.com"
+        const val BASE_URL = "https://jeol-chin.com"
 //        private const val BASE_URL = "http://61.79.96.183:8080"
 
 

--- a/data/src/main/java/com/yapp/android2/data/service/interceptor/HeaderInterceptor.kt
+++ b/data/src/main/java/com/yapp/android2/data/service/interceptor/HeaderInterceptor.kt
@@ -1,27 +1,73 @@
 package com.yapp.android2.data.service.interceptor
 
 import android.content.Context
-import com.yapp.android2.domain.key.ACCESS_TOKEN_KEY
-import com.yapp.android2.domain.key.AUTHORIZED
-import com.yapp.android2.domain.key.SHARED_PREFERENCE_KEY
+import android.content.Intent
+import androidx.core.content.edit
+import com.google.gson.Gson
+import com.yapp.android2.data.service.Service.Companion.BASE_URL
+import com.yapp.android2.domain.entity.RenewalResponse
+import com.yapp.android2.domain.key.*
 import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 class HeaderInterceptor @Inject constructor(
-    @ApplicationContext context: Context
+    @ApplicationContext private val context: Context,
+    private val gson: Gson
 ) : Interceptor {
 
     private val preference by lazy {
         context.getSharedPreferences(SHARED_PREFERENCE_KEY, Context.MODE_PRIVATE)
     }
 
-    override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = preference.getString(ACCESS_TOKEN_KEY, "").orEmpty()
-        val authorization = "Bearer $accessToken"
-        val header = chain.request().newBuilder().addHeader(AUTHORIZED, authorization).build()
+    private var accessToken: String = ""
+        get() = preference.getString(ACCESS_TOKEN_KEY, "").orEmpty()
+        set(token) {
+            preference.edit(true) { putString(ACCESS_TOKEN_KEY, token) }
+            field = token
+        }
 
-        return chain.proceed(header)
+    private fun authorization(token: String): String = "Bearer $token"
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder().addHeader(AUTHORIZED, authorization(accessToken)).build()
+        val response = chain.proceed(request)
+        when (response.code) {
+            401 -> {
+                val refreshToken = preference.getString(REFRESH_TOKEN_KEY, "").orEmpty()
+
+                for (i in 1..REPEAT_NUM) {
+                    val renewalTokenRequest = chain.request().newBuilder().get().url("${BASE_URL}/api/token")
+                        .addHeader(AUTHORIZED, authorization(refreshToken)).build()
+                    val renewalTokenResponse = chain.proceed(renewalTokenRequest)
+
+                    if (renewalTokenResponse.isSuccessful) {
+                        val newAccessTokenData = gson.fromJson(
+                            renewalTokenResponse.body?.string(),
+                            RenewalResponse::class.java
+                        )
+
+                        accessToken = newAccessTokenData.data.accessToken.toString()
+                        val newRequest = chain.request().newBuilder().addHeader(AUTHORIZED, authorization(accessToken)).build()
+                        return chain.proceed(newRequest)
+                    }
+                }
+                /** 리프레시 토큰 만료
+                 * 1. 토큰 삭제
+                 * 2. 로그인 화면으로 이동 */
+                removeTokens() // 1. 토큰 삭제
+            }
+        }
+        return response
+    }
+
+    private fun removeTokens(){
+        preference.edit(true) { remove(ACCESS_TOKEN_KEY) }
+        preference.edit(true) { remove(REFRESH_TOKEN_KEY) }
+    }
+
+    companion object {
+        private const val REPEAT_NUM = 3
     }
 }

--- a/domain/src/main/java/com/yapp/android2/domain/entity/RenewalResponse.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/entity/RenewalResponse.kt
@@ -1,0 +1,9 @@
+package com.yapp.android2.domain.entity
+
+import com.yapp.android2.domain.entity.base.BaseResponse
+
+data class RenewalResponse(override val data: Data) : BaseResponse<RenewalResponse.Data>() {
+    data class Data(
+        val accessToken: String?
+    )
+}

--- a/domain/src/main/java/com/yapp/android2/domain/key/Key.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/key/Key.kt
@@ -8,4 +8,6 @@ const val ACCESS_TOKEN_KEY = "BestFriend-Access-Token"
 
 const val KAKAO_ACCESS_TOKEN_KEY = "BestFriend-Kakao-Access-Token"
 
+const val REFRESH_TOKEN = "BestFriend-Refresh-Token"
+
 const val USER = "user"

--- a/domain/src/main/java/com/yapp/android2/domain/key/Key.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/key/Key.kt
@@ -8,6 +8,6 @@ const val ACCESS_TOKEN_KEY = "BestFriend-Access-Token"
 
 const val KAKAO_ACCESS_TOKEN_KEY = "BestFriend-Kakao-Access-Token"
 
-const val REFRESH_TOKEN = "BestFriend-Refresh-Token"
+const val REFRESH_TOKEN_KEY = "BestFriend-Refresh-Token"
 
 const val USER = "user"

--- a/domain/src/main/java/com/yapp/android2/domain/repository/login/LoginRepository.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/repository/login/LoginRepository.kt
@@ -11,6 +11,8 @@ interface LoginRepository : Repository {
     fun getAccessToken(): String
     fun saveKakaoAccessToken(kakaoToken: String)
     fun getKakaoAccessToken(): String
+    fun saveRefreshToken(refreshToken: String)
+    fun getRefreshToken(): String
     fun saveUser(user: User)
     fun getUser(): User
 }

--- a/domain/src/main/java/com/yapp/android2/domain/usecase/LoginUseCase.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/usecase/LoginUseCase.kt
@@ -22,9 +22,15 @@ class LoginUseCase @Inject constructor(
         loginRepository.saveKakaoAccessToken(token)
     }
 
+    fun saveRefreshToken(token: String){
+        loginRepository.saveRefreshToken(token)
+    }
+
     fun getAccessToken(): String = loginRepository.getAccessToken()
 
     fun getKakaoAccessToken(): String = loginRepository.getKakaoAccessToken()
+
+    fun getRefreshToken(): String = loginRepository.getRefreshToken()
 
     fun saveUser(userId: Long, nickname: String) {
         val user = User(userId, nickname)

--- a/presentation/login/src/main/java/com/best/friends/login/LoginViewModel.kt
+++ b/presentation/login/src/main/java/com/best/friends/login/LoginViewModel.kt
@@ -17,10 +17,16 @@ class LoginViewModel @Inject constructor(
 ) : BaseViewModel() {
     private val _user = MutableLiveData<LoginRequest>()
     val user: LiveData<LoginRequest> = _user
+
     private val _accessToken = MutableLiveData<String>()
     val accessToken: LiveData<String> = _accessToken
+
+    private val _refreshToken = MutableLiveData<String>()
+    val refreshToken: LiveData<String> = _refreshToken
+
     private val _kakaoAccessToken = MutableLiveData<String>()
     val kakaoAccessToken: LiveData<String> = _kakaoAccessToken
+
     private val _isSuccess = MutableLiveData(false)
     val isSuccess: LiveData<Boolean> = _isSuccess
 
@@ -38,10 +44,13 @@ class LoginViewModel @Inject constructor(
             kotlin.runCatching {
                 loginUseCase.login(userData)
             }.onSuccess {
-                loginUseCase.saveAccessToken(requireNotNull(it.data.accessToken))
                 Timber.i("액세스 토큰 : ${it.data.accessToken}")
+                loginUseCase.saveAccessToken(requireNotNull(it.data.accessToken))
+                loginUseCase.saveRefreshToken(requireNotNull(it.data.refreshToken))
                 loginUseCase.saveUser(it.data.userId ?: 0, it.data.nickName.orEmpty())
+
                 _accessToken.postValue(requireNotNull(it.data.accessToken))
+                _refreshToken.postValue(requireNotNull(it.data.refreshToken))
                 _isSuccess.postValue(true)
             }.onFailure {
                 Timber.e("$it")


### PR DESCRIPTION
완료
- interceptor에서 액세스 토큰 만료 확인(401)시 리프레시 토큰을 이용하여 액세스 토큰 재발급 받는 과정 추가
- 리프레시 토큰 만료 시 로그인 화면으로 진입할 수 있도록 변경
---
해결안된 것
- 뒤로가기 시 기존 홈 화면 등으로 진입하게 됨 (flag 설정에 대해 공부 필요)