### PR TITLE
절약 추가/수정 화면 - 2차 QA반영 + 수정/삭제시 팝업 노출 추가 

### DIFF
--- a/core-design-system/src/main/res/drawable/bg_rect_white_r20.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_white_r20.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white" />
+    <corners android:radius="20dp" />
+
+</shape>

--- a/core-design-system/src/main/res/values/colors.xml
+++ b/core-design-system/src/main/res/values/colors.xml
@@ -14,7 +14,8 @@
     <color name="color_sub">#A5C6FF</color>
     <color name="color_sub_25">#32A5C6FF</color>
 
-    <color name="black">#FF000000</color>
+    <color name="black">#000000</color>
+    <color name="black70">#B2000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="white80">#CCFFFFFF</color>
 

--- a/core-design-system/src/main/res/values/strings.xml
+++ b/core-design-system/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
     <string name="common_register">등록</string>
     <string name="common_delete">삭제</string>
     <string name="common_update">수정</string>
+    <string name="common_cancel">취소</string>
 
 </resources>

--- a/core/src/main/java/com/best/friends/core/BindingAdapters.kt
+++ b/core/src/main/java/com/best/friends/core/BindingAdapters.kt
@@ -1,0 +1,9 @@
+package com.best.friends.core
+
+import android.view.View
+import androidx.databinding.BindingAdapter
+
+@BindingAdapter("android:visibility")
+fun setVisibility(view: View, visible: Boolean) {
+    view.visibility = if (visible) View.VISIBLE else View.GONE
+}

--- a/domain/src/main/java/com/yapp/android2/domain/entity/Product.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/entity/Product.kt
@@ -18,7 +18,7 @@ data class Product(
         get() = try {
             DecimalFormat("###,###").format(price.toInt())
         } catch (e: Exception) {
-            price.toString()
+            price
         }
 
     val wonPrice: String

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
@@ -1,15 +1,17 @@
 package com.best.friends.home.dialog
 
-import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.setFragmentResult
-import androidx.fragment.app.setFragmentResultListener
+import androidx.lifecycle.LifecycleOwner
 import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.home.databinding.FragmentDialogHorizontalButtonsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,6 +32,8 @@ class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
     ): View {
         binding = FragmentDialogHorizontalButtonsBinding.inflate(inflater)
         binding.lifecycleOwner = viewLifecycleOwner
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
         return binding.root
     }
 
@@ -62,14 +66,16 @@ class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
         private const val RESULT_NEGATIVE_ACTION = "result_negative_action"
         private const val RESULT_POSITIVE_ACTION = "result_positive_action"
 
-        fun newInstance(
+        fun show(
+            fragmentManager: FragmentManager,
+            lifecycleOwner: LifecycleOwner,
             title: String,
             description: String,
             negativeButtonName: String,
             negativeAction: () -> Unit = {},
             positiveButtonName: String,
             positiveAction: () -> Unit = {},
-        ): HorizontalButtonsDialogFragment {
+        ) {
             return HorizontalButtonsDialogFragment().apply {
                 arguments = bundleOf(
                     TITLE to title,
@@ -77,7 +83,8 @@ class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
                     NEGATIVE_BUTTON_NAME to negativeButtonName,
                     POSITIVE_BUTTON_NAME to positiveButtonName
                 )
-                setFragmentResultListener(RESULT) { _, bundle ->
+            }.also {
+                fragmentManager.setFragmentResultListener(RESULT, lifecycleOwner) { _, bundle ->
                     when {
                         bundle.getBoolean(RESULT_NEGATIVE_ACTION, false) -> {
                             negativeAction.invoke()
@@ -87,15 +94,7 @@ class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
                         }
                     }
                 }
-            }
-        }
-
-        fun HorizontalButtonsDialogFragment.show(fragmentManager: FragmentManager) {
-            fragmentManager.executePendingTransactions()
-            val fragment = fragmentManager.findFragmentByTag(TAG)
-            if (fragment == null && !isAdded) {
-                show(fragmentManager, TAG)
-            }
+            }.show(fragmentManager, TAG)
         }
     }
 }

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
@@ -1,0 +1,101 @@
+package com.best.friends.home.dialog
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
+import com.best.friends.core.setOnSingleClickListener
+import com.best.friends.home.databinding.FragmentDialogHorizontalButtonsBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
+
+    private lateinit var binding: FragmentDialogHorizontalButtonsBinding
+    private val title by lazy { arguments?.getString(TITLE).orEmpty() }
+    private val description by lazy { arguments?.getString(DESCRIPTION).orEmpty() }
+    private val negativeButtonName by lazy { arguments?.getString(NEGATIVE_BUTTON_NAME).orEmpty() }
+    private val positiveButtonName by lazy { arguments?.getString(POSITIVE_BUTTON_NAME).orEmpty() }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentDialogHorizontalButtonsBinding.inflate(inflater)
+        binding.lifecycleOwner = viewLifecycleOwner
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.tvTitle.text = title
+        binding.tvDescription.text = description
+        binding.tvNegative.text = negativeButtonName
+        binding.tvPositive.text = positiveButtonName
+
+        binding.tvNegative.setOnSingleClickListener {
+            setFragmentResult(RESULT, bundleOf(RESULT_NEGATIVE_ACTION to true))
+            dismiss()
+        }
+        binding.tvPositive.setOnSingleClickListener {
+            setFragmentResult(RESULT, bundleOf(RESULT_POSITIVE_ACTION to true))
+            dismiss()
+        }
+    }
+
+    companion object {
+        private const val TITLE = "title"
+        private const val DESCRIPTION = "description"
+        private const val NEGATIVE_BUTTON_NAME = "negative_button_name"
+        private const val POSITIVE_BUTTON_NAME = "positive_button_name"
+        private const val TAG = "HorizontalButtonsDialogFragment"
+
+        private const val RESULT = "result"
+        private const val RESULT_NEGATIVE_ACTION = "result_negative_action"
+        private const val RESULT_POSITIVE_ACTION = "result_positive_action"
+
+        fun newInstance(
+            title: String,
+            description: String,
+            negativeButtonName: String,
+            negativeAction: () -> Unit = {},
+            positiveButtonName: String,
+            positiveAction: () -> Unit = {},
+        ): HorizontalButtonsDialogFragment {
+            return HorizontalButtonsDialogFragment().apply {
+                arguments = bundleOf(
+                    TITLE to title,
+                    DESCRIPTION to description,
+                    NEGATIVE_BUTTON_NAME to negativeButtonName,
+                    POSITIVE_BUTTON_NAME to positiveButtonName
+                )
+                setFragmentResultListener(RESULT) { _, bundle ->
+                    when {
+                        bundle.getBoolean(RESULT_NEGATIVE_ACTION, false) -> {
+                            negativeAction.invoke()
+                        }
+                        bundle.getBoolean(RESULT_POSITIVE_ACTION, false) -> {
+                            positiveAction.invoke()
+                        }
+                    }
+                }
+            }
+        }
+
+        fun HorizontalButtonsDialogFragment.show(fragmentManager: FragmentManager) {
+            fragmentManager.executePendingTransactions()
+            val fragment = fragmentManager.findFragmentByTag(TAG)
+            if (fragment == null && !isAdded) {
+                show(fragmentManager, TAG)
+            }
+        }
+    }
+}

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
@@ -14,9 +14,7 @@ import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.LifecycleOwner
 import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.home.databinding.FragmentDialogHorizontalButtonsBinding
-import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint
 class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {
 
     private lateinit var binding: FragmentDialogHorizontalButtonsBinding

--- a/presentation/home/src/main/java/com/best/friends/home/home/SavingsListAdapter.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/home/SavingsListAdapter.kt
@@ -88,7 +88,7 @@ internal class SavingsListAdapter(
             product = data.product
             binding.product = product
             binding.checkbox.setOnCheckedChangeListener(null)
-            binding.checkbox.isChecked = (product.checked == true)
+            binding.checkbox.isChecked = (product.checked)
             binding.checkbox.setOnCheckedChangeListener { _, _ ->
                 onItemChecked.invoke(product)
             }

--- a/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddActivity.kt
@@ -79,16 +79,6 @@ class SavingItemAddActivity :
     }
 
     private fun initView() {
-        val filter = InputFilter { source, start, end, _, _, _ ->
-            for (i in start until end) {
-                if (Character.isWhitespace(source[i])) {
-                    return@InputFilter ""
-                }
-            }
-            null
-        }
-
-        binding.etItemContent.filters = arrayOf(filter)
         binding.etItemPrice.inputType = TYPE_CLASS_NUMBER or TYPE_NUMBER_VARIATION_PASSWORD
         binding.etItemPrice.transformationMethod = null
     }
@@ -109,7 +99,25 @@ class SavingItemAddActivity :
             }
             .launchIn(lifecycleScope)
 
-        binding.etItemPrice.setOnFocusChangeListener { view, hasFocus ->
+        binding.etItemContent.setOnFocusChangeListener { _, hasFocus ->
+            val editText = binding.etItemContent
+            val whiteSpaceFilter = InputFilter { source, start, end, _, _, _ ->
+                if (binding.etItemContent.text.isBlank()) {
+                    for (i in start until end) {
+                        if (Character.isWhitespace(source[i])) {
+                            return@InputFilter ""
+                        }
+                    }
+                }
+                null
+            }
+
+            if (hasFocus) {
+                editText.filters = arrayOf(whiteSpaceFilter)
+            }
+        }
+
+        binding.etItemPrice.setOnFocusChangeListener { _, hasFocus ->
             val editText = binding.etItemPrice
             val price = viewModel.price.value
             if (price.isBlank()) {

--- a/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddActivity.kt
@@ -16,6 +16,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.best.friends.core.BaseActivity
 import com.best.friends.core.setOnSingleClickListener
+import com.best.friends.core.ui.Empty
 import com.best.friends.core.ui.showToast
 import com.best.friends.home.R
 import com.best.friends.home.databinding.ActivitySavingItemAddBinding
@@ -81,6 +82,22 @@ class SavingItemAddActivity :
     private fun initView() {
         binding.etItemPrice.inputType = TYPE_CLASS_NUMBER or TYPE_NUMBER_VARIATION_PASSWORD
         binding.etItemPrice.transformationMethod = null
+
+        binding.ivClearContent.setOnSingleClickListener {
+            viewModel.setContentText(String.Empty)
+            val editText = binding.etItemContent
+            editText.requestFocus()
+            val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.showSoftInput(editText, 0)
+        }
+
+        binding.ivClearPrice.setOnSingleClickListener {
+            viewModel.setPriceText(String.Empty)
+            val editText = binding.etItemPrice
+            editText.requestFocus()
+            val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.showSoftInput(editText, 0)
+        }
     }
 
     private fun observe() {

--- a/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddViewModel.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/register/SavingItemAddViewModel.kt
@@ -25,6 +25,10 @@ class SavingItemAddViewModel @Inject constructor(
     val action: SharedFlow<Action>
         get() = _action
 
+    fun setContentText(text: String) {
+        content.value = text
+    }
+
     fun setPriceText(text: String) {
         price.value = text
     }

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -133,6 +133,26 @@ class SavingItemUpdateActivity :
             val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
             imm.showSoftInput(editText, 0)
         }
+
+        binding.tvUpdate.setOnSingleClickListener {
+            showConfirmDialogFragment(
+                title = getString(R.string.saving_item_update_popup_title),
+                description = getString(R.string.saving_item_update_popup_description),
+                negativeButtonName = getString(common_cancel),
+                positiveButtonName = getString(common_update),
+                positiveAction = { viewModel.onUpdateClick() }
+            )
+        }
+
+        binding.tvDelete.setOnSingleClickListener {
+            showConfirmDialogFragment(
+                title = getString(R.string.saving_item_delete_popup_title),
+                description = getString(R.string.saving_item_delete_popup_description),
+                negativeButtonName = getString(common_cancel),
+                positiveButtonName = getString(common_delete),
+                positiveAction = { viewModel.onDeleteClick() }
+            )
+        }
     }
 
     private fun setToolbar() {
@@ -152,22 +172,12 @@ class SavingItemUpdateActivity :
             .onEach { action ->
                 when (action) {
                     Update -> {
-                        showConfirmDialogFragment(
-                            title = getString(R.string.saving_item_update_popup_title),
-                            description = getString(R.string.saving_item_update_popup_description),
-                            negativeButtonName = getString(common_cancel),
-                            positiveButtonName = getString(common_update),
-                            positiveAction = { setResult(RESULT_OK); finish() }
-                        )
+                        setResult(RESULT_OK)
+                        finish()
                     }
                     Delete -> {
-                        showConfirmDialogFragment(
-                            title = getString(R.string.saving_item_delete_popup_title),
-                            description = getString(R.string.saving_item_delete_popup_description),
-                            negativeButtonName = getString(common_cancel),
-                            positiveButtonName = getString(common_delete),
-                            positiveAction = { setResult(RESULT_OK); finish() }
-                        )
+                        setResult(RESULT_OK)
+                        finish()
                     }
                     Finish -> finish()
                 }

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -14,18 +14,23 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.best.friend.design.R.string.common_cancel
+import com.best.friend.design.R.string.common_delete
+import com.best.friend.design.R.string.common_update
 import com.best.friends.core.BaseActivity
 import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.core.ui.Empty
 import com.best.friends.core.ui.showToast
 import com.best.friends.home.R
 import com.best.friends.home.databinding.ActivitySavingItemUpdateBinding
+import com.best.friends.home.dialog.HorizontalButtonsDialogFragment
+import com.best.friends.home.update.SavingItemUpdateViewModel.Action.Delete
+import com.best.friends.home.update.SavingItemUpdateViewModel.Action.Update
 import com.yapp.android2.domain.entity.Product
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.text.DecimalFormat
-
 
 /**
  * 절약 수정 화면 Activity
@@ -137,11 +142,47 @@ class SavingItemUpdateActivity :
             .launchIn(lifecycleScope)
 
         viewModel.action
-            .onEach { _ ->
-                setResult(Activity.RESULT_OK)
-                finish()
+            .onEach { action ->
+                when (action) {
+                    Update -> {
+                        showConfirmDialogFragment(
+                            title = getString(R.string.saving_item_update_popup_title),
+                            description = getString(R.string.saving_item_update_popup_description),
+                            negativeButtonName = getString(common_cancel),
+                            positiveButtonName = getString(common_update),
+                            positiveAction = { setResult(Activity.RESULT_OK); finish() }
+                        )
+                    }
+                    Delete -> {
+                        showConfirmDialogFragment(
+                            title = getString(R.string.saving_item_delete_popup_title),
+                            description = getString(R.string.saving_item_delete_popup_description),
+                            negativeButtonName = getString(common_cancel),
+                            positiveButtonName = getString(common_delete),
+                            positiveAction = { setResult(Activity.RESULT_OK); finish() }
+                        )
+                    }
+                }
             }
             .launchIn(lifecycleScope)
+    }
+
+    private fun showConfirmDialogFragment(
+        title: String,
+        description: String,
+        negativeButtonName: String,
+        negativeAction: () -> Unit = {},
+        positiveButtonName: String,
+        positiveAction: () -> Unit = {}
+    ) {
+        HorizontalButtonsDialogFragment.newInstance(
+            title = title,
+            description = description,
+            negativeButtonName = negativeButtonName,
+            negativeAction = negativeAction,
+            positiveButtonName = positiveButtonName,
+            positiveAction = positiveAction
+        )
     }
 
     companion object {

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -76,17 +76,6 @@ class SavingItemUpdateActivity :
     }
 
     private fun initView() {
-        val filter = InputFilter { source, start, end, _, _, _ ->
-            for (i in start until end) {
-                if (Character.isWhitespace(source[i])) {
-                    return@InputFilter ""
-                }
-            }
-            null
-        }
-
-        binding.etItemContent.filters = arrayOf(filter)
-
         binding.etItemPrice.inputType = TYPE_CLASS_NUMBER or TYPE_NUMBER_VARIATION_PASSWORD
         binding.etItemPrice.transformationMethod = null
         binding.etItemPrice.setOnFocusChangeListener { _, hasFocus ->
@@ -96,8 +85,17 @@ class SavingItemUpdateActivity :
                 return@setOnFocusChangeListener
             }
 
+            val whiteSpaceFilter = InputFilter { source, start, end, _, _, _ ->
+                for (i in start until end) {
+                    if (Character.isWhitespace(source[i])) {
+                        return@InputFilter ""
+                    }
+                }
+                null
+            }
+
             if (hasFocus) {
-                editText.filters = arrayOf<InputFilter>(InputFilter.LengthFilter(6))
+                editText.filters = arrayOf(whiteSpaceFilter, InputFilter.LengthFilter(6))
                 val onlyNumber = price
                     .replace(",", "")
                     .replace("원", "")

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -24,6 +24,7 @@ import com.best.friends.home.R
 import com.best.friends.home.databinding.ActivitySavingItemUpdateBinding
 import com.best.friends.home.dialog.HorizontalButtonsDialogFragment
 import com.best.friends.home.update.SavingItemUpdateViewModel.Action.Delete
+import com.best.friends.home.update.SavingItemUpdateViewModel.Action.Finish
 import com.best.friends.home.update.SavingItemUpdateViewModel.Action.Update
 import com.yapp.android2.domain.entity.Product
 import dagger.hilt.android.AndroidEntryPoint
@@ -168,6 +169,7 @@ class SavingItemUpdateActivity :
                             positiveAction = { setResult(RESULT_OK); finish() }
                         )
                     }
+                    Finish -> finish()
                 }
             }
             .launchIn(lifecycleScope)

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -175,7 +175,9 @@ class SavingItemUpdateActivity :
         positiveButtonName: String,
         positiveAction: () -> Unit = {}
     ) {
-        HorizontalButtonsDialogFragment.newInstance(
+        HorizontalButtonsDialogFragment.show(
+            supportFragmentManager,
+            lifecycleOwner = this,
             title = title,
             description = description,
             negativeButtonName = negativeButtonName,

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateActivity.kt
@@ -1,6 +1,5 @@
 package com.best.friends.home.update
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Rect
@@ -76,6 +75,24 @@ class SavingItemUpdateActivity :
     }
 
     private fun initView() {
+        binding.etItemContent.setOnFocusChangeListener { _, hasFocus ->
+            val editText = binding.etItemContent
+            val whiteSpaceFilter = InputFilter { source, start, end, _, _, _ ->
+                if (binding.etItemContent.text.isBlank()) {
+                    for (i in start until end) {
+                        if (Character.isWhitespace(source[i])) {
+                            return@InputFilter ""
+                        }
+                    }
+                }
+                null
+            }
+
+            if (hasFocus) {
+                editText.filters = arrayOf(whiteSpaceFilter)
+            }
+        }
+
         binding.etItemPrice.inputType = TYPE_CLASS_NUMBER or TYPE_NUMBER_VARIATION_PASSWORD
         binding.etItemPrice.transformationMethod = null
         binding.etItemPrice.setOnFocusChangeListener { _, hasFocus ->
@@ -85,17 +102,8 @@ class SavingItemUpdateActivity :
                 return@setOnFocusChangeListener
             }
 
-            val whiteSpaceFilter = InputFilter { source, start, end, _, _, _ ->
-                for (i in start until end) {
-                    if (Character.isWhitespace(source[i])) {
-                        return@InputFilter ""
-                    }
-                }
-                null
-            }
-
             if (hasFocus) {
-                editText.filters = arrayOf(whiteSpaceFilter, InputFilter.LengthFilter(6))
+                editText.filters = arrayOf(InputFilter.LengthFilter(6))
                 val onlyNumber = price
                     .replace(",", "")
                     .replace("원", "")
@@ -148,7 +156,7 @@ class SavingItemUpdateActivity :
                             description = getString(R.string.saving_item_update_popup_description),
                             negativeButtonName = getString(common_cancel),
                             positiveButtonName = getString(common_update),
-                            positiveAction = { setResult(Activity.RESULT_OK); finish() }
+                            positiveAction = { setResult(RESULT_OK); finish() }
                         )
                     }
                     Delete -> {
@@ -157,7 +165,7 @@ class SavingItemUpdateActivity :
                             description = getString(R.string.saving_item_delete_popup_description),
                             negativeButtonName = getString(common_cancel),
                             positiveButtonName = getString(common_delete),
-                            positiveAction = { setResult(Activity.RESULT_OK); finish() }
+                            positiveAction = { setResult(RESULT_OK); finish() }
                         )
                     }
                 }

--- a/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateViewModel.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/update/SavingItemUpdateViewModel.kt
@@ -37,15 +37,21 @@ class SavingItemUpdateViewModel @Inject constructor(
     fun onUpdateClick() {
         viewModelScope.launch {
             kotlin.runCatching {
-                val user = loginRepository.getUser()
-                productsRepository.updateProducts(
-                    productId = params.product.productId,
-                    userId = user.userId,
-                    name = content.value.trim(),
-                    price = price.value
-                        .replace(",", "")
-                        .replace("원", "")
-                )
+                val name = content.value.trim()
+                val price = price.value
+                    .replace(",", "")
+                    .replace("원", "")
+                if (params.product.name != name || params.product.price != price) {
+                    val user = loginRepository.getUser()
+                    productsRepository.updateProducts(
+                        productId = params.product.productId,
+                        userId = user.userId,
+                        name = name,
+                        price = price
+                    )
+                } else {
+                    return@launch _action.emit(Action.Finish)
+                }
             }.onSuccess {
                 _action.emit(Action.Update)
             }.onFailure { throwable ->
@@ -69,6 +75,7 @@ class SavingItemUpdateViewModel @Inject constructor(
     data class Params(val product: Product)
 
     sealed class Action {
+        object Finish : Action()
         object Update : Action()
         object Delete : Action()
     }

--- a/presentation/home/src/main/res/layout/activity_saving_item_add.xml
+++ b/presentation/home/src/main/res/layout/activity_saving_item_add.xml
@@ -89,6 +89,18 @@
                     tools:ignore="LabelFor"
                     tools:text="아메리카노" />
 
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_clear_content"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_marginEnd="14dp"
+                    android:padding="6dp"
+                    android:visibility="@{!viewModel.content.empty}"
+                    app:layout_constraintBottom_toBottomOf="@id/et_item_content"
+                    app:layout_constraintEnd_toEndOf="@id/et_item_content"
+                    app:layout_constraintTop_toTopOf="@id/et_item_content"
+                    app:srcCompat="@drawable/icon_close" />
+
                 <TextView
                     android:id="@+id/tv_price_title"
                     android:layout_width="wrap_content"
@@ -120,6 +132,18 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_price_title"
                     tools:ignore="LabelFor"
                     tools:text="4,500원" />
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_clear_price"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_marginEnd="14dp"
+                    android:padding="6dp"
+                    android:visibility="@{!viewModel.price.empty}"
+                    app:layout_constraintBottom_toBottomOf="@id/et_item_price"
+                    app:layout_constraintEnd_toEndOf="@id/et_item_price"
+                    app:layout_constraintTop_toTopOf="@id/et_item_price"
+                    app:srcCompat="@drawable/icon_close" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/home/src/main/res/layout/activity_saving_item_update.xml
+++ b/presentation/home/src/main/res/layout/activity_saving_item_update.xml
@@ -19,28 +19,28 @@
             android:id="@+id/toolbar"
             android:layout_width="0dp"
             android:layout_height="?android:attr/actionBarSize"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintTop_toTopOf="parent">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/iv_back"
                 android:layout_width="42dp"
                 android:layout_height="42dp"
                 android:padding="12dp"
-                app:srcCompat="@drawable/icon_chevron_left"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/icon_chevron_left" />
 
             <TextView
                 android:id="@+id/tv_toolbar_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="@style/Typography.H2.Medium"
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toEndOf="@id/iv_back"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:text="절약 수정" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
@@ -95,6 +95,7 @@
                     android:layout_height="30dp"
                     android:layout_marginEnd="14dp"
                     android:padding="6dp"
+                    android:visibility="@{!viewModel.content.empty}"
                     app:layout_constraintBottom_toBottomOf="@id/et_item_content"
                     app:layout_constraintEnd_toEndOf="@id/et_item_content"
                     app:layout_constraintTop_toTopOf="@id/et_item_content"
@@ -137,6 +138,7 @@
                     android:layout_height="30dp"
                     android:layout_marginEnd="14dp"
                     android:padding="6dp"
+                    android:visibility="@{!viewModel.price.empty}"
                     app:layout_constraintBottom_toBottomOf="@id/et_item_price"
                     app:layout_constraintEnd_toEndOf="@id/et_item_price"
                     app:layout_constraintTop_toTopOf="@id/et_item_price"

--- a/presentation/home/src/main/res/layout/activity_saving_item_update.xml
+++ b/presentation/home/src/main/res/layout/activity_saving_item_update.xml
@@ -156,16 +156,15 @@
             android:layout_marginBottom="30dp"
             android:background="@drawable/bg_rect_gray2_r10"
             android:gravity="center"
-            android:onClick="@{() -> viewModel.onDeleteClick()}"
             android:text="@string/common_delete"
             android:textAppearance="@style/Typography.Button1.Medium"
             android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/tv_add"
+            app:layout_constraintEnd_toStartOf="@id/tv_update"
             app:layout_constraintStart_toStartOf="parent" />
 
         <TextView
-            android:id="@+id/tv_add"
+            android:id="@+id/tv_update"
             android:layout_width="0dp"
             android:layout_height="46dp"
             android:layout_marginStart="10dp"
@@ -174,7 +173,6 @@
             android:background="@drawable/selector_saving_add_button"
             android:enabled="@{!viewModel.content.empty &amp;&amp; !viewModel.price.empty, default=false}"
             android:gravity="center"
-            android:onClick="@{() -> viewModel.onUpdateClick()}"
             android:text="@string/common_update"
             android:textAppearance="@style/Typography.Button1.Medium"
             android:textColor="@color/white"

--- a/presentation/home/src/main/res/layout/fragment_dialog_horizontal_buttons.xml
+++ b/presentation/home/src/main/res/layout/fragment_dialog_horizontal_buttons.xml
@@ -7,7 +7,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minWidth="270dp"
-
         android:background="@drawable/bg_rect_white_r20">
 
         <TextView

--- a/presentation/home/src/main/res/layout/fragment_dialog_horizontal_buttons.xml
+++ b/presentation/home/src/main/res/layout/fragment_dialog_horizontal_buttons.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="270dp"
+
+        android:background="@drawable/bg_rect_white_r20">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="26dp"
+            android:layout_marginHorizontal="18dp"
+            android:gravity="center"
+            android:textAppearance="@style/Typography.Body3.Bold"
+            android:textColor="@color/black"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="정말 수정하시겠어요?" />
+
+        <TextView
+            android:id="@+id/tv_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginHorizontal="18dp"
+            android:gravity="center_horizontal"
+            android:textAppearance="@style/Typography.Body5.Regular"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="지금부터 수정한 내용이\n기록 화면에 적용되어 보일거에요." />
+
+        <TextView
+            android:id="@+id/tv_negative"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:background="@drawable/bg_rect_gray2_r10"
+            android:gravity="center"
+            android:layout_marginTop="12dp"
+            android:layout_marginStart="18dp"
+            android:layout_marginBottom="20dp"
+            android:textAppearance="@style/Typography.Button2.Medium"
+            android:textColor="@color/white"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_description"
+            app:layout_constraintEnd_toStartOf="@id/tv_positive"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="취소" />
+
+        <TextView
+            android:id="@+id/tv_positive"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:background="@drawable/bg_rect_primary_r10"
+            android:gravity="center"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="18dp"
+            android:textAppearance="@style/Typography.Button2.Medium"
+            android:textColor="@color/white"
+            app:layout_constraintStart_toEndOf="@id/tv_negative"
+            app:layout_constraintTop_toTopOf="@id/tv_negative"
+            app:layout_constraintBottom_toBottomOf="@id/tv_negative"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="수정" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/presentation/home/src/main/res/layout/layout_saving_item.xml
+++ b/presentation/home/src/main/res/layout/layout_saving_item.xml
@@ -50,16 +50,16 @@
 
         <TextView
             android:id="@+id/tv_name"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
             android:text="@{product.name}"
-            android:maxLength="6"
             android:maxLines="1"
             android:ellipsize="end"
             android:textAppearance="@style/Typography.H2.Bold"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/checkbox_click_sections"
             app:layout_constraintStart_toEndOf="@id/checkbox"
             tools:text="아메리카노" />
 

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -18,4 +18,10 @@
     <string name="saving_items_price_title">회당 지출 금액</string>
     <string name="saving_items_price_hint">예) 4,500원</string>
 
+    <!-- 절약 수정/삭제 팝업 -->
+    <string name="saving_item_update_popup_title">정말 수정하시겠어요?</string>
+    <string name="saving_item_update_popup_description">지금부터 수정한 내용이\n기록 화면에 적용되어 보일거예요.</string>
+    <string name="saving_item_delete_popup_title">정말 삭제하시겠어요?</string>
+    <string name="saving_item_delete_popup_description">삭제하시면 되돌릴 수 없어요.</string>
+
 </resources>

--- a/presentation/notification/src/main/AndroidManifest.xml
+++ b/presentation/notification/src/main/AndroidManifest.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.best.friends.notification">
-
-</manifest>
+<manifest package="com.best.friends.notification" />


### PR DESCRIPTION
- [x] 절약 수정 / 삭제할때, 한번더 의사를 물어보도록 팝업 추가 
- [x] 절약 추가/수정 화면에서, 항목 중간에 띄워쓰기를 할 수 없던 현상 수정
- [x] 절약 추가/수정 화면에서, 항목, 금액에 텍스트가 있을 경우에 "x버튼" 이 노출되도록 수정 
- [x] 절약항목을 수정할때, 항목/금액이 변경된 상황에서만 팝업 및 api호출하도록 처리


| 절약 수정시 | 절약 삭제시 |
| :---: | --- |
| <img src="https://user-images.githubusercontent.com/37705123/177027405-248b8c37-1005-473c-a3dd-bc18fd0e8778.jpg" width ="350" /> | <img src="https://user-images.githubusercontent.com/37705123/177027406-53a1e07f-afb5-4ca7-83a8-7769afb5d91c.jpg" width ="350" /> |

