### PR TITLE
[feature] 홈화면 > 오늘로 바로 돌아갈 수 있도록 DatePicker 추가

### DIFF
--- a/core-design-system/src/main/res/values/strings.xml
+++ b/core-design-system/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="common_cancel">취소</string>
     <string name="common_ok">확인</string>
 
+    <string name="common_today">오늘</string>
+
 </resources>

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
@@ -1,0 +1,106 @@
+package com.best.friends.home.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.setFragmentResult
+import androidx.lifecycle.LifecycleOwner
+import com.best.friends.core.setOnSingleClickListener
+import com.best.friends.home.databinding.FragmentDialogDatePickerTodayButtonBinding
+import java.time.ZonedDateTime
+
+class DatePickerWithTodayButtonDialog private constructor() : DialogFragment() {
+
+    fun interface DatePickerListener {
+        fun onDateSet(year: Int, month: Int, dayOfMonth: Int)
+    }
+
+    private lateinit var binding: FragmentDialogDatePickerTodayButtonBinding
+    private val year by lazy { arguments?.getInt(KEY_YEAR) ?: 0 }
+    private val month by lazy { arguments?.getInt(KEY_MONTH) ?: 0 }
+    private val dayOfMonth by lazy { arguments?.getInt(KEY_DAY_OF_MONTH) ?: 0 }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentDialogDatePickerTodayButtonBinding.inflate(inflater)
+        binding.lifecycleOwner = viewLifecycleOwner
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.datePicker.init(year, month, dayOfMonth, null)
+
+        binding.tvConfirm.setOnSingleClickListener {
+            setFragmentResult(RESULT, bundleOf(RESULT_POSITIVE_ACTION to true))
+            dismiss()
+        }
+
+        binding.tvCancel.setOnSingleClickListener {
+            dismiss()
+        }
+
+        // 오늘 클릭
+        binding.tvToday.setOnSingleClickListener {
+            setFragmentResult(RESULT, bundleOf(RESULT_TODAY_ACTION to true))
+            dismiss()
+        }
+    }
+
+    companion object {
+        private const val TAG = "HorizontalButtonsDialogFragment"
+
+        private const val KEY_YEAR = "year"
+        private const val KEY_MONTH = "month"
+        private const val KEY_DAY_OF_MONTH = "dayOfMonth"
+
+        private const val RESULT = "result"
+        private const val RESULT_POSITIVE_ACTION = "result_positive_action"
+        private const val RESULT_TODAY_ACTION = "result_today_action"
+
+        fun show(
+            fragmentManager: FragmentManager,
+            lifecycleOwner: LifecycleOwner,
+            year: Int,
+            month: Int, // 0~11
+            dayOfMonth: Int,
+            listener: DatePickerListener
+        ) {
+            return DatePickerWithTodayButtonDialog().apply {
+                arguments = bundleOf(
+                    KEY_YEAR to year,
+                    KEY_MONTH to month,
+                    KEY_DAY_OF_MONTH to dayOfMonth
+                )
+            }.also {
+                fragmentManager.setFragmentResultListener(RESULT, lifecycleOwner) { _, bundle ->
+                    when {
+                        bundle.getBoolean(RESULT_POSITIVE_ACTION, false) -> {
+                            listener.onDateSet(
+                                year = bundle.getInt(KEY_YEAR),
+                                month = bundle.getInt(KEY_MONTH),
+                                dayOfMonth = bundle.getInt(KEY_DAY_OF_MONTH)
+                            )
+                        }
+                        bundle.getBoolean(RESULT_TODAY_ACTION, false) -> {
+                            val today = ZonedDateTime.now()
+                            listener.onDateSet(
+                                year = today.year,
+                                month = today.monthValue,
+                                dayOfMonth = today.dayOfMonth
+                            )
+                        }
+                    }
+                }
+            }.show(fragmentManager, TAG)
+        }
+    }
+}

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.DatePicker
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
@@ -20,6 +21,9 @@ class DatePickerWithTodayButtonDialog private constructor() : DialogFragment() {
     }
 
     private lateinit var binding: FragmentDialogDatePickerTodayButtonBinding
+    private val datePicker: DatePicker
+        get() = binding.datePicker
+
     private val year by lazy { arguments?.getInt(KEY_YEAR) ?: 0 }
     private val month by lazy { arguments?.getInt(KEY_MONTH) ?: 0 }
     private val dayOfMonth by lazy { arguments?.getInt(KEY_DAY_OF_MONTH) ?: 0 }
@@ -37,10 +41,18 @@ class DatePickerWithTodayButtonDialog private constructor() : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.datePicker.init(year, month, dayOfMonth, null)
+        datePicker.init(year, month, dayOfMonth, null)
 
         binding.tvConfirm.setOnSingleClickListener {
-            setFragmentResult(RESULT, bundleOf(RESULT_POSITIVE_ACTION to true))
+            setFragmentResult(
+                requestKey = RESULT,
+                result = bundleOf(
+                    RESULT_POSITIVE_ACTION to true,
+                    KEY_YEAR to datePicker.year,
+                    KEY_MONTH to datePicker.month,
+                    KEY_DAY_OF_MONTH to datePicker.dayOfMonth
+                )
+            )
             dismiss()
         }
 

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/DatePickerWithTodayButtonDialog.kt
@@ -106,7 +106,7 @@ class DatePickerWithTodayButtonDialog private constructor() : DialogFragment() {
                             val today = ZonedDateTime.now()
                             listener.onDateSet(
                                 year = today.year,
-                                month = today.monthValue,
+                                month = today.monthValue - 1,
                                 dayOfMonth = today.dayOfMonth
                             )
                         }

--- a/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/dialog/HorizontalButtonsDialogFragment.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.best.friend.design.R.*
 import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.core.ui.visibleOrGone
-import com.best.friends.home.R
 import com.best.friends.home.databinding.FragmentDialogHorizontalButtonsBinding
 
 class HorizontalButtonsDialogFragment private constructor() : DialogFragment() {

--- a/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
@@ -149,7 +149,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             listener = { year, month, dayOfMonth ->
                 val new = ZonedDateTime.of(
                     year,
-                    month,
+                    month + 1,
                     dayOfMonth,
                     0, 0, 0, 0, ZoneId.systemDefault()
                 )

--- a/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
@@ -1,7 +1,6 @@
 package com.best.friends.home.home
 
 import android.app.Activity
-import android.app.DatePickerDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,6 +16,7 @@ import com.best.friends.core.ui.showToast
 import com.best.friends.core.ui.visibleOrGone
 import com.best.friends.home.R
 import com.best.friends.home.databinding.FragmentHomeBinding
+import com.best.friends.home.dialog.DatePickerWithTodayButtonDialog
 import com.best.friends.home.home.HomeViewModel.Action.CalendarClick
 import com.best.friends.home.register.SavingItemAddActivity
 import com.best.friends.home.update.SavingItemUpdateActivity
@@ -140,16 +140,23 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun showDatePicker(zonedDateTime: ZonedDateTime) {
-        DatePickerDialog(requireContext(), { _, year, month, dayOfMonth ->
-            val new = ZonedDateTime.of(
-                year,
-                month + 1,
-                dayOfMonth,
-                0, 0, 0, 0, ZoneId.systemDefault()
-            )
+        DatePickerWithTodayButtonDialog.show(
+            fragmentManager = childFragmentManager,
+            lifecycleOwner = viewLifecycleOwner,
+            year = zonedDateTime.year,
+            month = zonedDateTime.month.value - 1,
+            dayOfMonth = zonedDateTime.dayOfMonth,
+            listener = { year, month, dayOfMonth ->
+                val new = ZonedDateTime.of(
+                    year,
+                    month + 1,
+                    dayOfMonth,
+                    0, 0, 0, 0, ZoneId.systemDefault()
+                )
 
-            viewModel.getProductsSelectDay(new)
-        }, zonedDateTime.year, zonedDateTime.month.value - 1, zonedDateTime.dayOfMonth).show()
+                viewModel.getProductsSelectDay(new)
+            }
+        )
     }
 
     private fun startSavingUpdateActivity(product: Product) {

--- a/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
@@ -149,7 +149,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             listener = { year, month, dayOfMonth ->
                 val new = ZonedDateTime.of(
                     year,
-                    month + 1,
+                    month,
                     dayOfMonth,
                     0, 0, 0, 0, ZoneId.systemDefault()
                 )

--- a/presentation/home/src/main/res/layout/fragment_dialog_date_picker_today_button.xml
+++ b/presentation/home/src/main/res/layout/fragment_dialog_date_picker_today_button.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/white">
+
+        <DatePicker
+            android:id="@+id/date_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/date_picker">
+
+            <TextView
+                android:id="@+id/tv_confirm"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="10dp"
+                android:text="@string/common_ok"
+                android:textAppearance="@style/Typography.Button2.Medium"
+                android:textColor="@color/color_primary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_cancel"
+                android:layout_width="76dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center|end"
+                android:padding="10dp"
+                android:text="@string/common_cancel"
+                android:textAppearance="@style/Typography.Button2.Medium"
+                android:textColor="@color/color_primary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/tv_confirm"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_today"
+                android:layout_width="76dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="10dp"
+                android:gravity="center"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="10dp"
+                android:text="@string/common_today"
+                android:textAppearance="@style/Typography.Button2.Medium"
+                android:textColor="@color/color_primary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
홈화면 상단 > 달력 버튼 > 오늘로 바로 돌아갈 수 있도록 DatePicker를 커스텀 하는 작업입니다.
기본적인 Date Picker UI는 머터리얼 디자인 컴포넌트 스타일 그대로 사용했고, 하단 버튼 레이아웃만 직접 만들었어요 


| 피그마 디자인 | 구현된 모습 스크린샷 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/37705123/178099051-0af7a2f9-7a64-4d6b-9b6d-0004a7cfe446.png" width ="250" /> | <img src="https://user-images.githubusercontent.com/37705123/178099114-4b4f4222-dcba-40a8-90be-69128260d89e.png" width ="250" /> |

| 시연 영상 |
| :---: |
| <video src="https://user-images.githubusercontent.com/37705123/178099147-06130162-a754-4bb4-a17c-0f08e42b36f2.mp4" /> |