### PR TITLE
[ Fix ] : 전반적인 기록 로직을 수정했어요

### DIFF
--- a/data/src/main/java/com/yapp/android2/data/repository/RecordRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/android2/data/repository/RecordRepositoryImpl.kt
@@ -5,6 +5,9 @@ import com.yapp.android2.domain.entity.Product
 import com.yapp.android2.domain.entity.User
 import com.yapp.android2.domain.repository.record.Item
 import com.yapp.android2.domain.repository.record.RecordRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class RecordRepositoryImpl @Inject constructor(
@@ -12,23 +15,39 @@ class RecordRepositoryImpl @Inject constructor(
 ) : RecordRepository {
 
     override suspend fun fetchRecordsOrThrow(recordMM: String): List<Item> {
-
-        val savingList = recordRemoteDataSource.fetchRecords(recordMM)
-        val summaryList = recordRemoteDataSource.fetchSummaryRecord(recordMM)
+        val cacheDates = mutableMapOf<String, List<String>>()
 
 
-        val checkedItems = savingList.flatMap { savingItem ->
-            summaryList.filter { savingItem.name == it.name }
-                .map {
-                    Item(
-                        record = savingItem,
-                        totalCount = it.baseTimes,
-                        timesComparedToPrev = it.timesComparedToPrev
-                    )
-                }
+        val savingList = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                recordRemoteDataSource.fetchRecords(recordMM)
+            }
+
+        val summaryList = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+            recordRemoteDataSource.fetchSummaryRecord(recordMM)
         }
 
-        return checkedItems.distinctBy { it.record.name }
+        val flatSummary = savingList.flatMap { item ->
+
+            cacheDates[item.name] = emptyList()
+
+            summaryList.filter { item.name == it.name }.map {
+                it.copy(recordYmd = item.recordYmd) to item
+            }
+        }
+
+        val groups = flatSummary.groupBy { it.first.name }
+
+        val checkedItems = flatSummary.map { (summary, record) ->
+            Item(
+                record = record.copy(price = groups.getValue(summary.name)
+                    .sumOf { it.second.price }),
+                totalCount = summary.baseTimes,
+                timesComparedToPrev = summary.timesComparedToPrev,
+                recordDates = groups.getValue(summary.name).map { it.first.recordYmd }
+            )
+        }
+
+        return checkedItems
     }
 
     override suspend fun updateRecords(product: Product, user: User) {

--- a/domain/src/main/java/com/yapp/android2/domain/entity/base/Record.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/entity/base/Record.kt
@@ -24,6 +24,7 @@ data class Summary(
     val prevTimes: Int,
     val timesComparedToPrev: Int,
     override val name: String,
-    override val recordYmd: String
+    override val recordYmd: String,
+    val price: Int?
 ): Entity, Record
 

--- a/domain/src/main/java/com/yapp/android2/domain/repository/record/RecordRepository.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/repository/record/RecordRepository.kt
@@ -12,6 +12,7 @@ interface RecordRepository : Repository {
 
 data class Item(
     val record: Response,
+    val recordDates: List<String>,
     val totalCount: Int,
     val timesComparedToPrev: Int
 )

--- a/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/best/friends/home/home/HomeFragment.kt
@@ -6,14 +6,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
-import androidx.core.os.bundleOf
-import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.best.friends.core.BaseFragment
-import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.core.extensions.showToast
 import com.best.friends.core.extensions.visibleOrGone
+import com.best.friends.core.setOnSingleClickListener
 import com.best.friends.home.R
 import com.best.friends.home.databinding.FragmentHomeBinding
 import com.best.friends.home.dialog.DatePickerWithTodayButtonDialog
@@ -23,8 +22,7 @@ import com.best.friends.home.update.SavingItemUpdateActivity
 import com.best.friends.navigator.NotificationNavigator
 import com.best.friends.navigator.SettingNavigator
 import com.yapp.android2.domain.entity.Product
-import com.yapp.android2.domain.key.PRODUCT
-import com.yapp.android2.domain.key.PRODUCT_RESULT
+import com.yapp.android2.record.RecordViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -40,6 +38,7 @@ import javax.inject.Inject
 class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.fragment_home) {
 
     override val viewModel by viewModels<HomeViewModel>()
+    private val recordViewModel by activityViewModels<RecordViewModel>()
 
     @Inject
     lateinit var settingNavigator: SettingNavigator
@@ -60,7 +59,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             onItemChecked = { product ->
                 viewModel.checkSavingItem(product)
 
-                setFragmentResult(PRODUCT_RESULT, bundleOf(PRODUCT to product))
+                recordViewModel.onItemClick()
             }
         )
     }

--- a/presentation/record/src/main/java/com/yapp/android2/record/BindingAdapter.kt
+++ b/presentation/record/src/main/java/com/yapp/android2/record/BindingAdapter.kt
@@ -20,17 +20,6 @@ fun TextView.bindTotalSaving(items: List<Item>?) {
     }
 }
 
-@BindingAdapter("app:savingItems")
-fun CalendarView.bindSavingItems(items: List<Item>?) {
-    if(items == null) {
-        return
-    }
-
-    dayBinder = DayBind.newInstance(items)
-    setup(firstMonth, lastMonth, firstDayOfWeek)
-    scrollToMonth(currentMonth)
-}
-
 @BindingAdapter("app:itemSavingMessage")
 fun TextView.bindItemSavingMessage(timesComparedToPrev: Int?) {
     if(timesComparedToPrev == null) { return }

--- a/presentation/record/src/main/java/com/yapp/android2/record/RecordViewModel.kt
+++ b/presentation/record/src/main/java/com/yapp/android2/record/RecordViewModel.kt
@@ -6,10 +6,12 @@ import com.yapp.android2.domain.repository.record.Item
 import com.yapp.android2.domain.usecase.GetRecordUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,6 +23,10 @@ class RecordViewModel @Inject constructor(
     val items: StateFlow<List<Item>>
         get() = _items
 
+    private val _action = MutableSharedFlow<Action>()
+    val action: SharedFlow<Action>
+        get() = _action.asSharedFlow()
+
     var recordJob: Job? = null
 
     /**
@@ -31,7 +37,7 @@ class RecordViewModel @Inject constructor(
 
         recordJob = viewModelScope.launch {
             try {
-                val response = getRecordUseCase.execute(Unit).toMutableList()
+                val response = getRecordUseCase.execute(Unit)
 
                 _items.value = response
             } catch (exception: Exception) {
@@ -40,9 +46,19 @@ class RecordViewModel @Inject constructor(
         }
     }
 
+    fun onItemClick() {
+        viewModelScope.launch {
+            _action.emit(Action.ItemClick)
+        }
+    }
+
 
     override fun onCleared() {
         recordJob?.cancel()
         super.onCleared()
+    }
+
+    sealed class Action {
+        object ItemClick : Action()
     }
 }

--- a/presentation/record/src/main/java/com/yapp/android2/record/view/Calendar.kt
+++ b/presentation/record/src/main/java/com/yapp/android2/record/view/Calendar.kt
@@ -18,12 +18,11 @@ import java.time.ZoneId
 import java.time.temporal.WeekFields
 import java.util.*
 
-internal class DayBind(private val savingRecords: List<Item>) : DayBinder<DayContainer> {
+internal class DayBind(private val savingRecords: List<String> = emptyList()) : DayBinder<DayContainer> {
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun bind(container: DayContainer, day: CalendarDay) {
         container.textView.text = day.date.dayOfMonth.toString()
-        val savingDays = savingRecords.map { it.record.recordYmd }
 
         if(day.owner == DayOwner.THIS_MONTH) {
             container.textView.setTextColor(ContextCompat.getColor(container.view.context, design.color.gray4))
@@ -31,7 +30,7 @@ internal class DayBind(private val savingRecords: List<Item>) : DayBinder<DayCon
             container.textView.setTextColor(ContextCompat.getColor(container.view.context, design.color.gray2))
         }
 
-        val isSavingDay = savingDays.any {
+        val isSavingDay = savingRecords.any {
             val dateTime = DateTime.parse(it)
 
             dateTime.dayOfMonth().get() == day.date.dayOfMonth && dateTime.monthOfYear().get() == day.date.yearMonth.monthValue
@@ -46,7 +45,7 @@ internal class DayBind(private val savingRecords: List<Item>) : DayBinder<DayCon
 
 
     companion object {
-        fun newInstance(savingRecords: List<Item>): DayBind = DayBind(savingRecords)
+        fun newInstance(savingRecords: List<String> = emptyList()): DayBind = DayBind(savingRecords)
     }
 }
 

--- a/presentation/record/src/main/res/drawable/shape_corner15_bg_ff8717.xml
+++ b/presentation/record/src/main/res/drawable/shape_corner15_bg_ff8717.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <corners android:radius="17dp" />
+    <corners android:radius="20dp" />
     <solid android:color="@color/color_primary" />
 </shape>

--- a/presentation/record/src/main/res/layout/fragment_record.xml
+++ b/presentation/record/src/main/res/layout/fragment_record.xml
@@ -65,7 +65,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="7dp"
             android:includeFontPadding="false"
-            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textAppearance="@style/Typography.Body4.Medium"
             android:textColor="@color/gray4"
             android:textSize="14sp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -163,8 +163,7 @@
             app:cv_scrollMode="paged"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/legendLayout"
-            app:savingItems="@{viewModel.items}" />
+            app:layout_constraintTop_toBottomOf="@+id/legendLayout" />
 
         <TextView
             android:id="@+id/tv_empty_title"

--- a/presentation/record/src/main/res/layout/item_record.xml
+++ b/presentation/record/src/main/res/layout/item_record.xml
@@ -51,6 +51,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
                 android:textColor="@color/gray4"
+                android:textAppearance="@style/Typography.Caption2.Regular"
                 app:layout_constraintBottom_toTopOf="@+id/divider"
                 app:layout_constraintStart_toStartOf="@+id/guideStart"
                 app:layout_constraintTop_toBottomOf="@+id/title"


### PR DESCRIPTION

## 수정사항
- 총 N번의 사항 rounded 17 -> 20
- n원 아꼈어요, 카드뷰 n원 스타일 지정
- 스크롤 될 때마다 기록 ymd 따라서 캘린더 뷰 갱신



|시연영상|
|-------|
|<video src="https://user-images.githubusercontent.com/38200246/178154569-528ed9b3-1c8c-4b95-880e-4f1949d57770.mp4"/>|

### withContext 사용 이유

복잡한 로직이 동반되기 때문에 withContext를 붙혀 해당 api response가 내려올 때 까지 대기하는게 맞다고 생각했습니다.
IO 에서 돌아가도록 구현