### PR TITLE
[FIX] 알림이 없는 경우 알림의 주황색 점 이미지 변경

### DIFF
--- a/domain/src/main/java/com/yapp/android2/domain/entity/Notification.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/entity/Notification.kt
@@ -1,9 +1,18 @@
 package com.yapp.android2.domain.entity
 
+import com.yapp.android2.domain.Entity
+import java.io.Serializable
+
 data class Notification(
     val title: String?,
     val body: String?,
     val elapsedTime: String?,
     val createAt: String?
-)
+): Entity, Serializable {
+
+    companion object {
+        const val INIT_TIME = "0000-00-00T00:00:00"
+    }
+
+}
 

--- a/domain/src/main/java/com/yapp/android2/domain/usecase/IsUnreadNotification.kt
+++ b/domain/src/main/java/com/yapp/android2/domain/usecase/IsUnreadNotification.kt
@@ -1,7 +1,9 @@
 package com.yapp.android2.domain.usecase
 
+import com.yapp.android2.domain.entity.Notification
 import com.yapp.android2.domain.repository.Notification.NotificationRepository
 import java.text.SimpleDateFormat
+import java.util.*
 import javax.inject.Inject
 
 /** 읽지 않은 알림이 있는지 판단
@@ -18,14 +20,14 @@ class IsUnreadNotification @Inject constructor(
             val remoteLastNotification = it.createAt
             val localLastNotification = notificationRepository.getLastNotificationTime()
             return when {
-                remoteLastNotification == null -> {
+                remoteLastNotification == Notification.INIT_TIME || remoteLastNotification.isNullOrEmpty() -> {
                     false
                 }
-                localLastNotification == "" -> {
+                localLastNotification.isEmpty() -> {
                     true
                 }
                 else -> {
-                    val remoteLastNotificationFormat = dateFormat.parse(remoteLastNotification)
+                    val remoteLastNotificationFormat = requireNotNull(dateFormat.parse(remoteLastNotification))
                     val localLastNotificationFormat = dateFormat.parse(localLastNotification)
                     remoteLastNotificationFormat.after(localLastNotificationFormat)
                 }


### PR DESCRIPTION
- 알림이 없는 경우 홈화면의 알림 이미지 리소스 변경
---

알림이 없는 경우 서버에서 받아오는 값이 `null`이라고 생각해서 벌어진 오류 였습니다....!
`null`이 아닌 `0000-00-00T00:00:00`로 내려오는 걸 확인하고 코드 변경했습니다