### PR TITLE
[FIX] 구글 로그인 실패 현상 해결

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -22,6 +22,14 @@
           }
         },
         {
+          "client_id": "238291040120-m43kejktruk2tk9frgigkkairo0cj8lb.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.yapp.android2",
+            "certificate_hash": "112386b2ac546c52fc012d61f91eb84964b2c472"
+          }
+        },
+        {
           "client_id": "238291040120-0hc84ta4jv65nvqvdrqge02peol4bj43.apps.googleusercontent.com",
           "client_type": 3
         }


### PR DESCRIPTION
- sns 로그인 실패 원인 예상 : 릴리즈용 apk 추출 시 필요한 릴리즈용 키해시 미등록
-> 구글 로그인의 경우 파이어베이스에 릴리즈용 키해시를 등록하니 해결되었습니다
-> 카카오의 경우 아직 오류가 뜨는 상태입니다...!